### PR TITLE
fix timestamps + include tour_id in filename

### DIFF
--- a/gpxcompiler.py
+++ b/gpxcompiler.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import gpxpy.gpx
 
@@ -128,12 +128,18 @@ class GpxCompiler:
         segment = gpxpy.gpx.GPXTrackSegment()
         track.segments.append(segment)
 
+        augment_timestamp = self.route[0].time == 0
+        start_date = datetime.strptime(self.tour['date'], "%Y-%m-%dT%H:%M:%S.%f%z")
+
         for coord in self.route:
             point = gpxpy.gpx.GPXTrackPoint(coord.lat, coord.lng)
             if coord.alt != coord.CONST_UNDEFINED:
                 point.elevation = coord.alt
             if coord.time != coord.CONST_UNDEFINED:
-                point.time = datetime.fromtimestamp(coord.time / 1000)
+                if augment_timestamp:
+                    point.time = start_date + timedelta(seconds=coord.time / 1000)
+                else:
+                    point.time = datetime.fromtimestamp(coord.time / 1000)
             segment.points.append(point)
 
         if not self.no_poi:

--- a/komoot-gpx.py
+++ b/komoot-gpx.py
@@ -30,7 +30,7 @@ def make_gpx(tour_id, api, output_dir, no_poi):
     tour = api.fetch_tour(str(tour_id))
     gpx = GpxCompiler(tour, api, no_poi)
 
-    path = f"{output_dir}/{sanitize_filename(tour['name'])}.gpx"
+    path = f"{output_dir}/{sanitize_filename(tour['name'])}-{tour_id}.gpx"
     f = open(path, "w", encoding="utf-8")
     f.write(gpx.generate())
     f.close()


### PR DESCRIPTION
When I downloaded gpx files, I had the same problem as #1 

I also noticed gpx timestamps were starting on unix epoch, unsure if this is a general problem or related how tracks end up in my komoot account.

