### PR TITLE
Enabled date to be prepended to output filename

### DIFF
--- a/komoot-gpx.py
+++ b/komoot-gpx.py
@@ -29,11 +29,15 @@ def usage():
     print('\t{:<2s}, {:<30s} {:<10s}'.format('-e', '--no-poi', 'Do not include highlights as POIs'))
 
 
-def make_gpx(tour_id, api, output_dir, no_poi):
+def make_gpx(tour_id, api, output_dir, no_poi, add_date):
     tour = api.fetch_tour(str(tour_id))
     gpx = GpxCompiler(tour, api, no_poi)
 
-    path = f"{output_dir}/{sanitize_filename(tour['name'])}-{tour_id}.gpx"
+    # Example date: 2022-01-02T12:26:41.795+01:00
+    # :10 extracts "2022-01-02" from this.
+    date_str = tour['date'][:10]+'_' if add_date else ''
+
+    path = f"{output_dir}/{date_str}{sanitize_filename(tour['name'])}-{tour_id}.gpx"
     f = open(path, "w", encoding="utf-8")
     f.write(gpx.generate())
     f.close()
@@ -47,6 +51,7 @@ def main(argv):
     pwd = ''
     print_tours = False
     no_poi = False
+    add_date = False
     typeFilter = "all"
     output_dir = os.getcwd()
 
@@ -112,9 +117,9 @@ def main(argv):
 
     if tour_selection == "all":
         for x in tours:
-            make_gpx(x, api, output_dir, no_poi)
+            make_gpx(x, api, output_dir, no_poi, add_date)
     else:
-        make_gpx(tour_selection, api, output_dir, no_poi)
+        make_gpx(tour_selection, api, output_dir, no_poi, add_date)
     print()
 
 

--- a/komoot-gpx.py
+++ b/komoot-gpx.py
@@ -21,6 +21,7 @@ def usage():
     print('\t{:<2s}, {:<30s} {:<10s}'.format('-l', '--list-tours', 'List all tours of the logged in user'))
     print('\t{:<2s}, {:<30s} {:<10s}'.format('-d', '--make-gpx=tour_id', 'Download tour as GPX'))
     print('\t{:<2s}, {:<30s} {:<10s}'.format('-a', '--make-all', 'Download all tours'))
+    print('\t{:<2s}, {:<30s} {:<10s}'.format('-D', '--add-date', 'Add date to file name'))
     print(bcolor.OKBLUE + '[Filters]' + bcolor.ENDC)
     print('\t{:<2s}, {:<30s} {:<10s}'.format('-f', '--filter=type', 'Filter by track type (either "planned" or '
                                                                     '"recorded")'))
@@ -56,7 +57,7 @@ def main(argv):
     output_dir = os.getcwd()
 
     try:
-        opts, args = getopt.getopt(argv, "hle:o:d:m:p:f:", ["list-tours", "make-gpx=", "mail=",
+        opts, args = getopt.getopt(argv, "ahleDo:d:m:p:f:", ["add-date", "list-tours", "make-gpx=", "mail=",
                                                         "pass=", "filter=", "no-poi", "output=", "make-all"])
     except getopt.GetoptError:
         usage()
@@ -75,6 +76,9 @@ def main(argv):
 
         elif opt in ("-e", "--no-poi"):
             no_poi = True
+
+        elif opt in ("-D", "--add-date"):
+            add_date = True
 
         elif opt in ("-d", "--make-gpx"):
             tour_selection = str(arg)


### PR DESCRIPTION
Great script! Saves a  lot of work.

When manually downloading from komoot, the default name of the file is `2022-12-03_870976034_my_tour.gpx`. I find it quite convenient to have the date prepended at the beginning. This pull request implements that functionality, to have consistent behavior between manual and automatic download.

Note that currently it is disabled for backwards compatibility. I did not implement command line option for this as I haven't worked with `getopt` before (I usually use `argparse`), and don't want to touch the interface of your script. It would be great if you could implement the command line option!